### PR TITLE
Add initial network study room prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+app/data.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# vnccc
+# Network Study Room Prototype
+
+This repository contains a minimal prototype for a "network study room".
+Users can register, log in and receive their own ephemeral desktop container.
+Other users' desktops are shown in read-only iframes.
+A simple chat is available on the home page.
+
+## Features
+
+- Registration and login stored in a local SQLite database.
+- Each logged in user receives a Docker container based on
+  `dorowu/ubuntu-desktop-lxde-vnc:latest` exposing a noVNC interface.
+- Up to 50 active containers are allowed. Inactive containers are removed
+  after 10 minutes.
+- Home page displays up to six desktops simultaneously (the current user and
+  others in view-only mode).
+- Chat implemented with Socket.IO.
+
+## Running
+
+```bash
+pip install -r requirements.txt
+python app/server.py
+```
+
+Open `http://localhost:5000` in your browser.
+
+This is only a proof of concept. Security aspects such as password hashing and
+resource isolation need to be improved for production use.

--- a/app/server.py
+++ b/app/server.py
@@ -1,0 +1,128 @@
+import os
+import socket
+from datetime import datetime, timedelta
+
+from flask import Flask, redirect, render_template, request, session, url_for
+from flask_sqlalchemy import SQLAlchemy
+from flask_socketio import SocketIO, emit
+import docker
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'secret'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///data.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+socketio = SocketIO(app)
+db = SQLAlchemy(app)
+client = docker.from_env()
+
+MAX_USERS = 50
+IMAGE = "dorowu/ubuntu-desktop-lxde-vnc:latest"
+INACTIVE_TIMEOUT = 600  # seconds
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password = db.Column(db.String(128), nullable=False)
+
+class Session(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    container_id = db.Column(db.String(64))
+    port = db.Column(db.Integer)
+    last_active = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+def get_free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def start_container(user):
+    port = get_free_port()
+    container = client.containers.run(
+        IMAGE,
+        detach=True,
+        ports={'6080/tcp': port}
+    )
+    sess = Session(user_id=user.id, container_id=container.id, port=port)
+    db.session.add(sess)
+    db.session.commit()
+    return sess
+
+
+def cleanup_inactive():
+    now = datetime.utcnow()
+    for sess in Session.query.all():
+        if now - sess.last_active > timedelta(seconds=INACTIVE_TIMEOUT):
+            try:
+                container = client.containers.get(sess.container_id)
+                container.remove(force=True)
+            except docker.errors.NotFound:
+                pass
+            db.session.delete(sess)
+    db.session.commit()
+
+
+@app.route('/', methods=['GET'])
+def index():
+    if 'user_id' not in session:
+        return redirect(url_for('login'))
+    cleanup_inactive()
+    user = User.query.get(session['user_id'])
+    sess = Session.query.filter_by(user_id=user.id).first()
+    if not sess and Session.query.count() < MAX_USERS:
+        sess = start_container(user)
+    sessions = Session.query.all()[:6]
+    return render_template('index.html', sessions=sessions, self_id=user.id)
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            return 'User exists', 400
+        user = User(username=username, password=password)
+        db.session.add(user)
+        db.session.commit()
+        session['user_id'] = user.id
+        return redirect(url_for('index'))
+    return render_template('register.html')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username, password=password).first()
+        if not user:
+            return 'Invalid credentials', 400
+        session['user_id'] = user.id
+        return redirect(url_for('index'))
+    return render_template('login.html')
+
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('login'))
+
+
+@socketio.on('chat')
+def handle_chat(msg):
+    emit('chat', msg, broadcast=True)
+
+
+def init_db():
+    db.create_all()
+
+
+if __name__ == '__main__':
+    init_db()
+    socketio.run(app, host='0.0.0.0', port=5000)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+<head>
+  <title>Desktops</title>
+  <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+  <script>
+    const socket = io();
+    socket.on('chat', msg => {
+      const div = document.createElement('div');
+      div.textContent = msg;
+      document.getElementById('chat').appendChild(div);
+    });
+    function send(){
+      const val = document.getElementById('msg').value;
+      socket.emit('chat', val);
+      document.getElementById('msg').value='';
+    }
+  </script>
+</head>
+<body>
+<div id="chat"></div>
+<input id="msg"><button onclick="send()">Send</button>
+<hr>
+<div style="display:flex; flex-wrap:wrap;">
+{% for s in sessions %}
+  <iframe src="http://localhost:{{s.port}}/vnc.html?view_only={{ 'true' if s.user_id != self_id else 'false' }}" width="320" height="240"></iframe>
+{% endfor %}
+</div>
+<a href="{{ url_for('logout') }}">Logout</a>
+</body>
+</html>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>Login</title>
+<form method="post">
+  <input name="username" placeholder="Username" required>
+  <input name="password" type="password" placeholder="Password" required>
+  <button type="submit">Login</button>
+</form>
+<a href="{{ url_for('register') }}">Register</a>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>Register</title>
+<form method="post">
+  <input name="username" placeholder="Username" required>
+  <input name="password" type="password" placeholder="Password" required>
+  <button type="submit">Register</button>
+</form>
+<a href="{{ url_for('login') }}">Login</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+flask
+flask_sqlalchemy
+flask_socketio
+python-socketio
+docker
+eventlet


### PR DESCRIPTION
## Summary
- implement Flask-based server to manage containerized desktops
- add basic login/register forms and chat widget
- create minimal templates for index/login/register
- describe usage in README
- add requirements and gitignore

## Testing
- `python3 -m py_compile app/server.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_b_6845401fc78883259264e8ddf03746d2