### PR TITLE
Add cleanup task and fullscreen view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+app/data.db

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ A simple chat is available on the home page.
 - Passwords stored using Werkzeug hashing.
 - Containers run with configurable memory and CPU limits.
 - Remaining time, online status and a fullscreen link shown for each desktop.
+- Usernames displayed next to each desktop.
+- Online status determined by client pings; interval and threshold can be
+  configured with environment variables.
 
 ## Running
 
@@ -39,6 +42,8 @@ DESKTOP_MEM=512m \
 DESKTOP_CPUS=0.5 \
 MAX_USERS=20 \
 INACTIVE_TIMEOUT=300 \
+ONLINE_THRESHOLD=5 \
+PING_INTERVAL=1 \
 SECRET_KEY=mysecret \
 python app/server.py
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# vnccc
+# Network Study Room Prototype
+
+This repository contains a minimal prototype for a "network study room".
+Users can register, log in and receive their own ephemeral desktop container.
+Other users' desktops are shown in read-only iframes.
+A simple chat is available on the home page.
+
+## Features
+
+- Registration and login stored in a local SQLite database.
+- Each logged in user receives a Docker container based on
+  `dorowu/ubuntu-desktop-lxde-vnc:latest` exposing a noVNC interface.
+- Up to 50 active containers are allowed. Inactive containers are removed
+  after 10 minutes.
+- Home page displays up to six desktops simultaneously (the current user and
+  others in view-only mode).
+- Chat implemented with Socket.IO.
+- Remaining capacity and connection status displayed.
+- Buttons to extend time or delete your container.
+- Background task cleans up inactive containers every minute.
+- Passwords stored using Werkzeug hashing.
+- Remaining time and a fullscreen link shown for each desktop.
+
+## Running
+
+```bash
+pip install -r requirements.txt
+python app/server.py
+```
+
+Open `http://localhost:5000` in your browser.
+
+This is only a proof of concept. Security and resource isolation need
+improvements before production use.

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ A simple chat is available on the home page.
   `dorowu/ubuntu-desktop-lxde-vnc:latest` exposing a noVNC interface.
 - Up to 50 active containers are allowed. Inactive containers are removed
   after 10 minutes.
-- Home page displays up to six desktops simultaneously (the current user and
-  others in view-only mode).
+- Home page lists all active desktops in a scrollable grid. Your own desktop is
+  interactive while others are view-only.
 - Chat implemented with Socket.IO.
 - Remaining capacity and connection status displayed.
 - Buttons to extend time or delete your container.
 - Background task cleans up inactive containers every minute.
 - Passwords stored using Werkzeug hashing.
+- Containers run with configurable memory and CPU limits.
 - Remaining time and a fullscreen link shown for each desktop.
 
 ## Running
@@ -26,6 +27,13 @@ A simple chat is available on the home page.
 ```bash
 pip install -r requirements.txt
 python app/server.py
+```
+
+Environment variables can be used to configure the Docker image and resource
+limits:
+
+```
+DESKTOP_IMAGE=your/image:tag DESKTOP_MEM=512m DESKTOP_CPUS=0.5 python app/server.py
 ```
 
 Open `http://localhost:5000` in your browser.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ A simple chat is available on the home page.
 - Home page lists all active desktops in a scrollable grid. Your own desktop is
   interactive while others are view-only.
 - Chat implemented with Socket.IO.
+- Messages in chat display the sender's username.
 - Remaining capacity and connection status displayed.
 - Buttons to extend time or delete your container.
 - Background task cleans up inactive containers every minute.
 - Passwords stored using Werkzeug hashing.
 - Containers run with configurable memory and CPU limits.
-- Remaining time and a fullscreen link shown for each desktop.
+- Remaining time, online status and a fullscreen link shown for each desktop.
 
 ## Running
 
@@ -29,11 +30,17 @@ pip install -r requirements.txt
 python app/server.py
 ```
 
-Environment variables can be used to configure the Docker image and resource
-limits:
+Environment variables can be used to configure the Docker image, resource limits
+and other options:
 
 ```
-DESKTOP_IMAGE=your/image:tag DESKTOP_MEM=512m DESKTOP_CPUS=0.5 python app/server.py
+DESKTOP_IMAGE=your/image:tag \
+DESKTOP_MEM=512m \
+DESKTOP_CPUS=0.5 \
+MAX_USERS=20 \
+INACTIVE_TIMEOUT=300 \
+SECRET_KEY=mysecret \
+python app/server.py
 ```
 
 Open `http://localhost:5000` in your browser.

--- a/app/server.py
+++ b/app/server.py
@@ -1,0 +1,210 @@
+import os
+import socket
+import threading
+from datetime import datetime, timedelta
+
+from flask import Flask, redirect, render_template, request, session as flask_session, url_for
+from flask_sqlalchemy import SQLAlchemy
+from flask_socketio import SocketIO, emit
+from werkzeug.security import generate_password_hash, check_password_hash
+import docker
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'secret'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///data.db'
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+socketio = SocketIO(app)
+db = SQLAlchemy(app)
+client = docker.from_env()
+
+MAX_USERS = 50
+IMAGE = "dorowu/ubuntu-desktop-lxde-vnc:latest"
+INACTIVE_TIMEOUT = 600  # seconds
+
+class User(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password = db.Column(db.String(128), nullable=False)
+
+class Session(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
+    container_id = db.Column(db.String(64))
+    port = db.Column(db.Integer)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    last_active = db.Column(db.DateTime, default=datetime.utcnow)
+
+
+def get_free_port():
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(('', 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def start_container(user):
+    port = get_free_port()
+    container = client.containers.run(
+        IMAGE,
+        detach=True,
+        ports={'6080/tcp': port}
+    )
+    sess = Session(user_id=user.id, container_id=container.id, port=port)
+    db.session.add(sess)
+    db.session.commit()
+    return sess
+
+
+def cleanup_inactive():
+    now = datetime.utcnow()
+    for sess in Session.query.all():
+        if now - sess.last_active > timedelta(seconds=INACTIVE_TIMEOUT):
+            try:
+                container = client.containers.get(sess.container_id)
+                container.remove(force=True)
+            except docker.errors.NotFound:
+                pass
+            db.session.delete(sess)
+    db.session.commit()
+
+
+def cleanup_loop():
+    while True:
+        socketio.sleep(60)
+        with app.app_context():
+            cleanup_inactive()
+
+
+@app.route('/extend')
+def extend():
+    if 'user_id' not in flask_session:
+        return redirect(url_for('login'))
+    sess = Session.query.filter_by(user_id=flask_session['user_id']).first()
+    if sess:
+        sess.last_active = datetime.utcnow()
+        db.session.commit()
+    return redirect(url_for('index'))
+
+
+@app.route('/delete')
+def delete():
+    if 'user_id' not in flask_session:
+        return redirect(url_for('login'))
+    sess = Session.query.filter_by(user_id=flask_session['user_id']).first()
+    if sess:
+        try:
+            container = client.containers.get(sess.container_id)
+            container.remove(force=True)
+        except docker.errors.NotFound:
+            pass
+        db.session.delete(sess)
+        db.session.commit()
+    return redirect(url_for('index'))
+
+
+@app.route('/', methods=['GET'])
+def index():
+    if 'user_id' not in flask_session:
+        return redirect(url_for('login'))
+    cleanup_inactive()
+    user = User.query.get(flask_session['user_id'])
+    sess = Session.query.filter_by(user_id=user.id).first()
+    if not sess and Session.query.count() < MAX_USERS:
+        sess = start_container(user)
+    remaining = MAX_USERS - Session.query.count()
+    session_info = []
+    now = datetime.utcnow()
+    for s in Session.query.all()[:6]:
+        remain = INACTIVE_TIMEOUT - int((now - s.last_active).total_seconds())
+        view_only = s.user_id != user.id
+        session_info.append({'session': s, 'remaining': max(0, remain), 'view_only': view_only})
+    return render_template('index.html', sessions=session_info, self_id=user.id, remaining=remaining)
+
+
+@app.route('/full/<int:sid>')
+def full_view(sid):
+    if 'user_id' not in flask_session:
+        return redirect(url_for('login'))
+    s = Session.query.get_or_404(sid)
+    view_only = 'true' if s.user_id != flask_session['user_id'] else 'false'
+    return render_template('full.html', session=s, view_only=view_only)
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        if User.query.filter_by(username=username).first():
+            return 'User exists', 400
+        user = User(username=username, password=generate_password_hash(password))
+        db.session.add(user)
+        db.session.commit()
+        flask_session['user_id'] = user.id
+        return redirect(url_for('index'))
+    return render_template('register.html')
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and not check_password_hash(user.password, password):
+            user = None
+        if not user:
+            return 'Invalid credentials', 400
+        flask_session['user_id'] = user.id
+        return redirect(url_for('index'))
+    return render_template('login.html')
+
+
+@app.route('/logout')
+def logout():
+    flask_session.clear()
+    return redirect(url_for('login'))
+
+
+@socketio.on('chat')
+def handle_chat(msg):
+    emit('chat', msg, broadcast=True)
+
+
+@socketio.on('ping')
+def handle_ping():
+    if 'user_id' in flask_session:
+        sess = Session.query.filter_by(user_id=flask_session['user_id']).first()
+        if sess:
+            sess.last_active = datetime.utcnow()
+            db.session.commit()
+
+
+@socketio.on('connect')
+def handle_connect():
+    if 'user_id' in flask_session:
+        sess = Session.query.filter_by(user_id=flask_session['user_id']).first()
+        if sess:
+            sess.last_active = datetime.utcnow()
+            db.session.commit()
+
+
+@socketio.on('disconnect')
+def handle_disconnect():
+    if 'user_id' in flask_session:
+        sess = Session.query.filter_by(user_id=flask_session['user_id']).first()
+        if sess:
+            sess.last_active = datetime.utcnow()
+            db.session.commit()
+
+
+def init_db():
+    db.create_all()
+
+
+if __name__ == '__main__':
+    init_db()
+    socketio.start_background_task(cleanup_loop)
+    socketio.run(app, host='0.0.0.0', port=5000)

--- a/app/templates/full.html
+++ b/app/templates/full.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+  <title>Desktop</title>
+</head>
+<body style="margin:0;">
+  <iframe src="http://localhost:{{session.port}}/vnc.html?view_only={{view_only}}" width="100%" height="100%" style="border:0;"></iframe>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,9 +16,10 @@
     socket.on('disconnect', () => {
       document.getElementById('status').textContent = '离线';
     });
+    const pingInterval = {{ ping_interval|default(1000) }};
     setInterval(() => {
       socket.emit('ping');
-    }, 5000);
+    }, pingInterval);
     function send(){
       const val = document.getElementById('msg').value;
       socket.emit('chat', val);
@@ -36,7 +37,7 @@
 {% for item in sessions %}
   {% set s = item.session %}
   <div style="margin:5px;">
-    <p>{{ '在线' if item.online else '离线' }}</p>
+    <p>{{ item.username }} - {{ '在线' if item.online else '离线' }}</p>
     <iframe src="http://localhost:{{s.port}}/vnc.html?view_only={{ 'true' if item.view_only else 'false' }}" width="320" height="240"></iframe>
     <p>剩余 {{ item.remaining }} 秒</p>
     <a href="{{ url_for('full_view', sid=s.id) }}">放大</a>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+<head>
+  <title>Desktops</title>
+  <script src="https://cdn.socket.io/4.7.5/socket.io.min.js"></script>
+  <script>
+    const socket = io();
+    socket.on('chat', msg => {
+      const div = document.createElement('div');
+      div.textContent = msg;
+      document.getElementById('chat').appendChild(div);
+    });
+    socket.on('connect', () => {
+      document.getElementById('status').textContent = '在线';
+    });
+    socket.on('disconnect', () => {
+      document.getElementById('status').textContent = '离线';
+    });
+    setInterval(() => {
+      socket.emit('ping');
+    }, 5000);
+    function send(){
+      const val = document.getElementById('msg').value;
+      socket.emit('chat', val);
+      document.getElementById('msg').value='';
+    }
+  </script>
+</head>
+<body>
+<p id="status"></p>
+<p>剩余机器: {{ remaining }}</p>
+<div id="chat"></div>
+<input id="msg"><button onclick="send()">Send</button>
+<hr>
+<div style="display:flex; flex-wrap:wrap;">
+{% for item in sessions %}
+  {% set s = item.session %}
+  <div style="margin:5px;">
+    <iframe src="http://localhost:{{s.port}}/vnc.html?view_only={{ 'true' if item.view_only else 'false' }}" width="320" height="240"></iframe>
+    <p>剩余 {{ item.remaining }} 秒</p>
+    <a href="{{ url_for('full_view', sid=s.id) }}">放大</a>
+    {% if not item.view_only %}
+      <div>
+        <a href="{{ url_for('extend') }}">续时间</a>
+        <a href="{{ url_for('delete') }}">删除</a>
+      </div>
+    {% endif %}
+  </div>
+{% endfor %}
+</div>
+<a href="{{ url_for('logout') }}">Logout</a>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -7,7 +7,7 @@
     const socket = io();
     socket.on('chat', msg => {
       const div = document.createElement('div');
-      div.textContent = msg;
+      div.textContent = msg.user + ': ' + msg.msg;
       document.getElementById('chat').appendChild(div);
     });
     socket.on('connect', () => {
@@ -36,6 +36,7 @@
 {% for item in sessions %}
   {% set s = item.session %}
   <div style="margin:5px;">
+    <p>{{ '在线' if item.online else '离线' }}</p>
     <iframe src="http://localhost:{{s.port}}/vnc.html?view_only={{ 'true' if item.view_only else 'false' }}" width="320" height="240"></iframe>
     <p>剩余 {{ item.remaining }} 秒</p>
     <a href="{{ url_for('full_view', sid=s.id) }}">放大</a>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>Login</title>
+<form method="post">
+  <input name="username" placeholder="Username" required>
+  <input name="password" type="password" placeholder="Password" required>
+  <button type="submit">Login</button>
+</form>
+<a href="{{ url_for('register') }}">Register</a>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<title>Register</title>
+<form method="post">
+  <input name="username" placeholder="Username" required>
+  <input name="password" type="password" placeholder="Password" required>
+  <button type="submit">Register</button>
+</form>
+<a href="{{ url_for('login') }}">Login</a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+flask
+flask_sqlalchemy
+flask_socketio
+python-socketio
+docker
+eventlet


### PR DESCRIPTION
## Summary
- store hashed passwords
- show remaining time for each session
- add background task to clean up inactive sessions
- add full page view for desktops
- document new features in README

## Testing
- `python3 -m py_compile app/server.py`
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_b_6845401fc78883259264e8ddf03746d2